### PR TITLE
IMDSv2 attempt should IMDSv1 fail

### DIFF
--- a/ec2_configinit
+++ b/ec2_configinit
@@ -16,14 +16,16 @@ rcvar=ec2_configinit_enable
 start_cmd="ec2_configinit_run"
 stop_cmd=":"
 
-CONFIGURL="http://169.254.169.254/latest/user-data"
+CONFIGURL="latest/user-data"
 
 ec2_configinit_run()
 {
 	# Download to a temporary location.
 	echo -n "Fetching EC2 user-data"
 	CONFFILE=`mktemp "${TMPDIR:-/tmp}/configinit.XXXXXX"`
-	fetch -o ${CONFFILE} ${CONFIGURL} 2>/dev/null
+	# Instead of using fetch use our new tool
+	# This will handle imds v1 vs v2
+	/usr/local/bin/aws-ec2-imdsv2-get ${CONFIGURL} > ${CONFFILE} 2>/dev/null
 
 	# If we succeeded, process it; otherwise report failure.
 	if [ $? = 0 ]; then
@@ -32,23 +34,6 @@ ec2_configinit_run()
 		echo -n "Processing EC2 user-data"
 		/usr/local/sbin/configinit $CONFFILE
 		echo .
-	else
-        # If we get here, chances are high that the user has disabled IMDSv1
-        # As such let's attempt to use it
-        pkg install -y curl
-        TOKEN=`/usr/local/bin/curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`
-
-        # Now attempt to fetch the user-data again with the appropriate token
-        /usr/local/bin/curl -o ${CONFFILE} -H "X-aws-ec2-metadata-token: ${TOKEN}" -v ${CONFIGURL}
-        if [ $? = 0 ]; then
-            # Process the user-data.
-            echo .
-            echo -n "Processing EC2 user-data"
-            /usr/local/sbin/configinit $CONFFILE
-            echo .
-        else
-    		echo " failed."
-        fi
 	fi
 
 	# Whether we suceeded or not, delete the temporary file.

--- a/ec2_configinit
+++ b/ec2_configinit
@@ -36,10 +36,10 @@ ec2_configinit_run()
         # If we get here, chances are high that the user has disabled IMDSv1
         # As such let's attempt to use it
         pkg install -y curl
-        TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`
+        TOKEN=`/usr/local/bin/curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`
 
         # Now attempt to fetch the user-data again with the appropriate token
-        curl -o ${CONFFILE} -H "X-aws-ec2-metadata-token: ${TOKEN}" -v ${CONFIGURL}
+        /usr/local/bin/curl -o ${CONFFILE} -H "X-aws-ec2-metadata-token: ${TOKEN}" -v ${CONFIGURL}
         if [ $? = 0 ]; then
             # Process the user-data.
             echo .

--- a/ec2_configinit
+++ b/ec2_configinit
@@ -33,7 +33,22 @@ ec2_configinit_run()
 		/usr/local/sbin/configinit $CONFFILE
 		echo .
 	else
-		echo " failed."
+        # If we get here, chances are high that the user has disabled IMDSv1
+        # As such let's attempt to use it
+        pkg install -y curl
+        TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`
+
+        # Now attempt to fetch the user-data again with the appropriate token
+        curl -o ${CONFFILE} -H "X-aws-ec2-metadata-token: ${TOKEN}" -v ${CONFIGURL}
+        if [ $? = 0 ]; then
+            # Process the user-data.
+            echo .
+            echo -n "Processing EC2 user-data"
+            /usr/local/sbin/configinit $CONFFILE
+            echo .
+        else
+    		echo " failed."
+        fi
 	fi
 
 	# Whether we suceeded or not, delete the temporary file.

--- a/ec2_fetchkey
+++ b/ec2_fetchkey
@@ -19,7 +19,7 @@ rcvar=ec2_fetchkey_enable
 start_cmd="ec2_fetchkey_run"
 stop_cmd=":"
 
-SSHKEYURL="http://169.254.169.254/latest/meta-data/public-keys/0/openssh-key"
+SSHKEYURL="latest/meta-data/public-keys/0/openssh-key"
 
 ec2_fetchkey_run()
 {
@@ -39,7 +39,8 @@ ec2_fetchkey_run()
 	mkdir -p `dirname ${SSHKEYFILE}`
 	chmod 700 `dirname ${SSHKEYFILE}`
 	chown ${ec2_fetchkey_user} `dirname ${SSHKEYFILE}`
-	ftp -o ${SSHKEYFILE}.ec2 -a ${SSHKEYURL} >/dev/null
+	# Instead of using ftp use our new tool
+	/usr/local/bin/aws-ec2-imdsv2-get ${SSHKEYURL} > ${SSHKEYFILE}.ec2 2>/dev/null
 	if [ -f ${SSHKEYFILE}.ec2 ]; then
 		touch ${SSHKEYFILE}
 		sort -u ${SSHKEYFILE} ${SSHKEYFILE}.ec2		\
@@ -47,22 +48,6 @@ ec2_fetchkey_run()
 		mv ${SSHKEYFILE}.tmp ${SSHKEYFILE}
 		chown ${ec2_fetchkey_user} ${SSHKEYFILE}
 		rm ${SSHKEYFILE}.ec2
-	else
-        # If we get here there is a likely-hood this is
-        # due to IMDSv2, so let's try with IMDSv2 auth
-        pkg install -y curl
-        TOKEN=`/usr/local/bin/curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`
-        /usr/local/bin/curl -H "X-aws-ec2-metadata-token: $TOKEN" -o ${SSHKEYFILE}.ec2 ${SSHKEYURL} >/dev/null
-        if [ -f ${SSHKEYFILE}.ec2 ]; then
-    		touch ${SSHKEYFILE}
-    		sort -u ${SSHKEYFILE} ${SSHKEYFILE}.ec2		\
-    		    > ${SSHKEYFILE}.tmp
-    		mv ${SSHKEYFILE}.tmp ${SSHKEYFILE}
-    		chown ${ec2_fetchkey_user} ${SSHKEYFILE}
-    		#rm ${SSHKEYFILE}.ec2
-        else
-    		echo "Fetching SSH public key failed!"
-        fi
 	fi
 }
 

--- a/ec2_fetchkey
+++ b/ec2_fetchkey
@@ -51,8 +51,8 @@ ec2_fetchkey_run()
         # If we get here there is a likely-hood this is
         # due to IMDSv2, so let's try with IMDSv2 auth
         pkg install -y curl
-        TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`
-        curl -H "X-aws-ec2-metadata-token: $TOKEN" -o ${SSHKEYFILE}.ec2 ${SSHKEYURL} >/dev/null
+        TOKEN=`/usr/local/bin/curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`
+        /usr/local/bin/curl -H "X-aws-ec2-metadata-token: $TOKEN" -o ${SSHKEYFILE}.ec2 ${SSHKEYURL} >/dev/null
         if [ -f ${SSHKEYFILE}.ec2 ]; then
     		touch ${SSHKEYFILE}
     		sort -u ${SSHKEYFILE} ${SSHKEYFILE}.ec2		\

--- a/ec2_fetchkey
+++ b/ec2_fetchkey
@@ -19,7 +19,7 @@ rcvar=ec2_fetchkey_enable
 start_cmd="ec2_fetchkey_run"
 stop_cmd=":"
 
-SSHKEYURL="http://169.254.169.254/1.0/meta-data/public-keys/0/openssh-key"
+SSHKEYURL="http://169.254.169.254/latest/meta-data/public-keys/0/openssh-key"
 
 ec2_fetchkey_run()
 {
@@ -48,7 +48,21 @@ ec2_fetchkey_run()
 		chown ${ec2_fetchkey_user} ${SSHKEYFILE}
 		rm ${SSHKEYFILE}.ec2
 	else
-		echo "Fetching SSH public key failed!"
+        # If we get here there is a likely-hood this is
+        # due to IMDSv2, so let's try with IMDSv2 auth
+        pkg install -y curl
+        TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`
+        curl -H "X-aws-ec2-metadata-token: $TOKEN" -o ${SSHKEYFILE}.ec2 ${SSHKEYURL} >/dev/null
+        if [ -f ${SSHKEYFILE}.ec2 ]; then
+    		touch ${SSHKEYFILE}
+    		sort -u ${SSHKEYFILE} ${SSHKEYFILE}.ec2		\
+    		    > ${SSHKEYFILE}.tmp
+    		mv ${SSHKEYFILE}.tmp ${SSHKEYFILE}
+    		chown ${ec2_fetchkey_user} ${SSHKEYFILE}
+    		#rm ${SSHKEYFILE}.ec2
+        else
+    		echo "Fetching SSH public key failed!"
+        fi
 	fi
 }
 


### PR DESCRIPTION
This isn't the prettiest way to do this, but I've added logic so that if IMDSv1 fail on bootup it will then install curl (cause i wasn't able to find a way to do PUT requests with fetch cause i'm a newb), then use curl to use IMDSv2 to get userdata and setup the ssh key. 

I am okay if changes are required, going to test this with our internal amis (basically swap the existing scripts for these in that ami)